### PR TITLE
Add shared Kafka event models and README for miniedu-model library

### DIFF
--- a/miniedu-model/.idea/.gitignore
+++ b/miniedu-model/.idea/.gitignore
@@ -1,0 +1,5 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Environment-dependent path to Maven home directory
+/mavenHomeManager.xml

--- a/miniedu-model/.idea/compiler.xml
+++ b/miniedu-model/.idea/compiler.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CompilerConfiguration">
+    <annotationProcessing>
+      <profile name="Maven default annotation processors profile" enabled="true">
+        <sourceOutputDir name="target/generated-sources/annotations" />
+        <sourceTestOutputDir name="target/generated-test-sources/test-annotations" />
+        <outputRelativeToContentRoot value="true" />
+        <module name="miniedu-model" />
+      </profile>
+    </annotationProcessing>
+  </component>
+</project>

--- a/miniedu-model/.idea/encodings.xml
+++ b/miniedu-model/.idea/encodings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Encoding">
+    <file url="file://$PROJECT_DIR$/src/main/java" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/src/main/resources" charset="UTF-8" />
+  </component>
+</project>

--- a/miniedu-model/.idea/jarRepositories.xml
+++ b/miniedu-model/.idea/jarRepositories.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RemoteRepositoriesConfiguration">
+    <remote-repository>
+      <option name="id" value="central" />
+      <option name="name" value="Central Repository" />
+      <option name="url" value="https://repo.maven.apache.org/maven2" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="central" />
+      <option name="name" value="Maven Central repository" />
+      <option name="url" value="https://repo1.maven.org/maven2" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="jboss.community" />
+      <option name="name" value="JBoss Community repository" />
+      <option name="url" value="https://repository.jboss.org/nexus/content/repositories/public/" />
+    </remote-repository>
+  </component>
+</project>

--- a/miniedu-model/.idea/misc.xml
+++ b/miniedu-model/.idea/misc.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ExternalStorageConfigurationManager" enabled="true" />
+  <component name="MavenProjectsManager">
+    <option name="originalFiles">
+      <list>
+        <option value="$PROJECT_DIR$/pom.xml" />
+      </list>
+    </option>
+  </component>
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="17" project-jdk-type="JavaSDK" />
+</project>

--- a/miniedu-model/.idea/vcs.xml
+++ b/miniedu-model/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$/.." vcs="Git" />
+  </component>
+</project>

--- a/miniedu-model/README.md
+++ b/miniedu-model/README.md
@@ -1,0 +1,48 @@
+# MiniEdu Model Library
+
+This is a shared Maven library for the MiniEdu Microservices Project.
+
+## Purpose
+
+The `miniedu-model` library contains common data models and event classes used for communication between microservices, such as Kafka events.
+
+Sharing these classes ensures:
+
+- Consistent data contracts across services
+- Reduced duplication of code
+- Easier maintenance and evolution of shared types
+
+## Included Event Classes
+
+- `PasswordResetEvent` — event data for password reset requests
+- `UserRegisteredEvent` — event data for user registration events
+- `EmailEvent` — common interface for email-related events
+
+## Usage
+
+1. Build and install the library locally:
+
+   ```bash
+   mvn clean install
+
+### 1. Add this dependency to your microservices’ pom.xml:
+
+```xml
+<dependency>
+  <groupId>com.miniedu.model</groupId>
+  <artifactId>miniedu-model</artifactId>
+  <version>1.0.0</version>
+</dependency>
+
+```
+
+### 2. Import and use the shared classes in your code:
+
+```java
+import com.miniedu.model.PasswordResetEvent;
+import com.miniedu.model.UserRegisteredEvent;
+```
+
+## Requirements
+- Java 17 or higher
+- Maven 3.6+

--- a/miniedu-model/pom.xml
+++ b/miniedu-model/pom.xml
@@ -1,0 +1,40 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+         https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.miniedu.model</groupId>
+  <artifactId>miniedu-model</artifactId>
+  <version>1.0.0</version>
+
+  <properties>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.11.0</version>
+        <configuration>
+          <source>17</source>
+          <target>17</target>
+        </configuration>
+      </plugin>
+      <!-- There's no need for unit tests in this Shared Model, hence why we skip tests -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.5.3</version>
+        <configuration>
+          <skipTests>true</skipTests>
+        </configuration>
+      </plugin>
+
+    </plugins>
+  </build>
+</project>
+

--- a/miniedu-model/src/main/java/com/miniedu/model/kafka/events/EmailEvent.java
+++ b/miniedu-model/src/main/java/com/miniedu/model/kafka/events/EmailEvent.java
@@ -1,0 +1,5 @@
+package com.miniedu.model.kafka.events;
+
+public interface EmailEvent {
+    String email();
+}

--- a/miniedu-model/src/main/java/com/miniedu/model/kafka/events/PasswordResetEvent.java
+++ b/miniedu-model/src/main/java/com/miniedu/model/kafka/events/PasswordResetEvent.java
@@ -1,0 +1,4 @@
+package com.miniedu.model.kafka.events;
+
+public record PasswordResetEvent(String email, String userId, String passwordResetToken) implements EmailEvent {
+}

--- a/miniedu-model/src/main/java/com/miniedu/model/kafka/events/UserRegisteredEvent.java
+++ b/miniedu-model/src/main/java/com/miniedu/model/kafka/events/UserRegisteredEvent.java
@@ -1,0 +1,4 @@
+package com.miniedu.model.kafka.events;
+
+public record UserRegisteredEvent(String email, String userId, String verificationToken) implements EmailEvent {
+}


### PR DESCRIPTION
### Overview

- Created the `miniedu-model` library to centralize shared Kafka event models used across multiple microservices.
- Added event records:
  - `PasswordResetEvent`
  - `UserRegisteredEvent`
- Both events implement the `EmailEvent` interface, ensuring a consistent contract.
- Included a `README.md` that explains the library’s purpose, usage, and setup.
- Configured the project to use Java 17 and eliminated test compilation issues.
- This shared model library promotes loose coupling by preventing direct dependency between producer and consumer microservices on event classes.

### Benefits

- Consistent serialization/deserialization of Kafka events across microservices.
- Easier maintenance and scalability as event models evolve.
- Clear separation of concerns between services.
