### PR TITLE
fix(kafka): resolve silent consumer failure and startup race condition

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,12 @@ services:
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
       ZOOKEEPER_TICK_TIME: 2000
+    healthcheck:
+      test: ["CMD-SHELL", "echo ruok | nc localhost 2181 || exit 1"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+      start_period: 10s
 
   kafka:
     image: confluentinc/cp-kafka:7.4.0
@@ -23,10 +29,17 @@ services:
       KAFKA_INTER_BROKER_LISTENER_NAME: INTERNAL
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
     depends_on:
-      - zookeeper
+      zookeeper:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "nc -z localhost 9092 || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 15s
 
   db:
-    image: postgres
+    image: postgres:16
     container_name: dev_postgresql
     restart: always
     ports:
@@ -34,8 +47,15 @@ services:
     environment:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: user-microservice
     volumes:
-      - local_pgdata:/var/lib/postgresql/data
+      - local_pgdata_v3:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d user-microservice"]
+      interval: 3s
+      timeout: 3s
+      retries: 5
+      start_period: 10s
 
   pgadmin:
     image: dpage/pgadmin4
@@ -56,16 +76,46 @@ services:
     ports:
       - "8888:8888"
     restart: on-failure
-    # 🌟 Uses basic curl check against the exposed dev endpoint instead of actuator
     healthcheck:
       test:
         [
           "CMD-SHELL",
-          "curl -f http://localhost:8888/user-service/dev || exit 1",
+          "curl -f http://localhost:8888/email-service/dev || exit 1",
         ]
       interval: 5s
       timeout: 3s
       retries: 10
+      start_period: 15s
+
+  user-service:
+    build:
+      context: ./user-service
+      dockerfile: Dockerfile
+    container_name: user-service
+    ports:
+      - "8081:8081"
+    environment:
+      SPRING_PROFILES_ACTIVE: ${SPRING_PROFILES_ACTIVE}
+      CONFIG_SERVER_URL: http://config-server:8888
+      POSTGRES_HOST: ${POSTGRES_HOST}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      KAFKA_BOOTSTRAP_SERVERS: ${KAFKA_BOOTSTRAP_SERVERS}
+      JWT_SECRET: ${JWT_SECRET}
+    depends_on:
+      db:
+        condition: service_healthy
+      kafka:
+        condition: service_healthy
+      config-server:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8081/actuator/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 40s
+    restart: on-failure
 
   email-service:
     build:
@@ -76,38 +126,19 @@ services:
     environment:
       SPRING_PROFILES_ACTIVE: ${SPRING_PROFILES_ACTIVE}
       CONFIG_SERVER_URL: http://config-server:8888
-      KAFKA_BOOTSTRAP_SERVERS: kafka:9092
+      KAFKA_BOOTSTRAP_SERVERS: ${KAFKA_BOOTSTRAP_SERVERS}
       MAIL_PASSWORD: ${MAIL_PASSWORD}
+      LOGGING_LEVEL_ORG_APACHE_KAFKA: DEBUG
+      LOGGING_LEVEL_ORG_SPRINGFRAMEWORK_KAFKA: DEBUG
     depends_on:
       kafka:
-        condition: service_started
+        condition: service_healthy
       config-server:
         condition: service_healthy
-    restart: on-failure
-
-  user-service:
-    build:
-      context: ./user-service
-    container_name: user-service
-    ports:
-      - "8081:8081"
-    environment:
-      SPRING_PROFILES_ACTIVE: ${SPRING_PROFILES_ACTIVE}
-      CONFIG_SERVER_URL: http://config-server:8888
-      POSTGRES_HOST: db
-      POSTGRES_USER: ${POSTGRES_USER}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
-      KAFKA_BOOTSTRAP_SERVERS: kafka:9092
-      JWT_SECRET: ${JWT_SECRET}
-    depends_on:
-      db:
-        condition: service_started
-      kafka:
-        condition: service_started
-      config-server:
+      user-service:
         condition: service_healthy
     restart: on-failure
 
 volumes:
-  local_pgdata:
+  local_pgdata_v3:
   pgadmin-data:

--- a/email-service/pom.xml
+++ b/email-service/pom.xml
@@ -1,35 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.4.5</version>
-		<relativePath/> <!-- lookup parent from repository -->
-	</parent>
+		<version>4.0.7</version> <relativePath/> </parent>
 	<groupId>com.miniedu</groupId>
 	<artifactId>email-service</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
 	<name>email-service</name>
 	<description>Email Microservice responsible for handling tasks related to email</description>
 	<url/>
-	<licenses>
-		<license/>
-	</licenses>
-	<developers>
-		<developer/>
-	</developers>
-	<scm>
-		<connection/>
-		<developerConnection/>
-		<tag/>
-		<url/>
-	</scm>
+
 	<properties>
 		<java.version>17</java.version>
-		<spring-cloud.version>2024.0.1</spring-cloud.version>
+		<spring-cloud.version>2025.1.0</spring-cloud.version>
 	</properties>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -73,12 +61,14 @@
 			<artifactId>spring-kafka-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+
 		<dependency>
 			<groupId>io.github.danikofficial</groupId>
 			<artifactId>miniedu-model</artifactId>
 			<version>1.0.0</version>
 		</dependency>
 	</dependencies>
+
 	<dependencyManagement>
 		<dependencies>
 			<dependency>
@@ -102,6 +92,10 @@
 							<groupId>org.projectlombok</groupId>
 							<artifactId>lombok</artifactId>
 						</path>
+						<path>
+							<groupId>org.springframework.boot</groupId>
+							<artifactId>spring-boot-configuration-processor</artifactId>
+						</path>
 					</annotationProcessorPaths>
 				</configuration>
 			</plugin>
@@ -119,5 +113,4 @@
 			</plugin>
 		</plugins>
 	</build>
-
 </project>

--- a/email-service/src/main/resources/application.yml
+++ b/email-service/src/main/resources/application.yml
@@ -2,8 +2,22 @@ spring:
   application:
     name: email-service
   config:
-    import: "configserver:${CONFIG_SERVER_URL:http://localhost:8888}"
-    name: email-service
+    import: "optional:configserver:${CONFIG_SERVER_URL:http://localhost:8888}"
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS}
+    consumer:
+      group-id: email-service-group
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      properties:
+        spring.json.trusted.packages: "com.miniedu.model.kafka.events"
+        spring.json.use.type.headers: true
 
 server:
   port: 8082
+
+logging:
+  level:
+    org.apache.kafka: DEBUG
+    org.springframework.kafka: DEBUG

--- a/miniedu-config-server/pom.xml
+++ b/miniedu-config-server/pom.xml
@@ -1,35 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.4.5</version>
-		<relativePath/> <!-- lookup parent from repository -->
-	</parent>
+		<version>4.0.7</version> <relativePath/> </parent>
 	<groupId>com.miniedu</groupId>
 	<artifactId>miniedu-config-server</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
 	<name>miniedu-config-server</name>
 	<description>Centralized Spring Cloud Config Server for MiniEdu Microservices</description>
 	<url/>
-	<licenses>
-		<license/>
-	</licenses>
-	<developers>
-		<developer/>
-	</developers>
-	<scm>
-		<connection/>
-		<developerConnection/>
-		<tag/>
-		<url/>
-	</scm>
+
 	<properties>
 		<java.version>17</java.version>
-		<spring-cloud.version>2024.0.1</spring-cloud.version>
+		<spring-cloud.version>2025.1.0</spring-cloud.version>
 	</properties>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
@@ -42,6 +30,7 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
+
 	<dependencyManagement>
 		<dependencies>
 			<dependency>
@@ -62,5 +51,4 @@
 			</plugin>
 		</plugins>
 	</build>
-
 </project>

--- a/security-lib/pom.xml
+++ b/security-lib/pom.xml
@@ -5,15 +5,14 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.4.5</version>
-        <relativePath/> <!-- lookup parent from repository -->
+        <version>4.0.7</version> <relativePath/>
     </parent>
     <groupId>io.github.danikofficial</groupId>
     <artifactId>security-lib</artifactId>
-    <version>1.0.0</version>
-    <name>security-lib</name>
+    <version>1.1.0</version> <name>security-lib</name>
     <description>JWT Authentication Library for MiniEdu microservices</description>
     <url>https://github.com/DanikOfficial/MiniEdu</url>
+
     <licenses>
         <license>
             <name>Apache License, Version 2.0</name>
@@ -31,9 +30,14 @@
         <developerConnection>scm:git:https://github.com/DanikOfficial/MiniEdu.git</developerConnection>
         <url>https://github.com/DanikOfficial/MiniEdu</url>
     </scm>
+
     <properties>
         <java.version>17</java.version>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <jjwt.version>0.12.6</jjwt.version>
     </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -51,47 +55,40 @@
             <scope>test</scope>
         </dependency>
 
-        <!-- JWT dependencies -->
         <dependency>
             <groupId>io.jsonwebtoken</groupId>
             <artifactId>jjwt-api</artifactId>
-            <version>0.11.5</version>
+            <version>${jjwt.version}</version>
         </dependency>
         <dependency>
             <groupId>io.jsonwebtoken</groupId>
             <artifactId>jjwt-impl</artifactId>
-            <version>0.11.5</version>
+            <version>${jjwt.version}</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>io.jsonwebtoken</groupId>
             <artifactId>jjwt-jackson</artifactId>
-            <version>0.11.5</version>
+            <version>${jjwt.version}</version>
             <scope>runtime</scope>
         </dependency>
 
-        <!-- Optional: Logging -->
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>2.0.9</version>
         </dependency>
-
     </dependencies>
 
     <build>
         <plugins>
-            <!-- Spring Boot Plugin (disabled for libraries) -->
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>3.4.5</version>
                 <configuration>
                     <skip>true</skip>
                 </configuration>
             </plugin>
 
-            <!-- Add maven-jar-plugin to ensure proper jar creation -->
             <plugin>
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>3.2.0</version>

--- a/security-lib/src/main/java/com/miniedu/securitylib/service/JwtServiceImpl.java
+++ b/security-lib/src/main/java/com/miniedu/securitylib/service/JwtServiceImpl.java
@@ -6,14 +6,13 @@ import com.miniedu.securitylib.model.JwtTokenData;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
-import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
-import java.security.Key;
+import javax.crypto.SecretKey;
+import io.jsonwebtoken.security.Keys;
 import java.time.Duration;
 import java.util.Date;
 
@@ -23,7 +22,7 @@ public class JwtServiceImpl implements JwtService {
     private static final Logger logger = LoggerFactory.getLogger(JwtServiceImpl.class);
 
     private final JwtProperties jwtProperties;
-    private Key secretKey;
+    private SecretKey secretKey;
 
     public JwtServiceImpl(JwtProperties jwtProperties) {
         this.jwtProperties = jwtProperties;
@@ -41,19 +40,16 @@ public class JwtServiceImpl implements JwtService {
         Date now = new Date();
         Date expiry = new Date(now.getTime() + jwtProperties.getExpiration());
 
-
         String token = Jwts.builder()
-                .setSubject(data.subject())
-                .addClaims(data.claims())
-                .setIssuer(jwtProperties.getIssuer())
-                .setIssuedAt(now)
-                .setExpiration(expiry)
-                .signWith(secretKey, SignatureAlgorithm.HS256)
+                .subject(data.subject())
+                .claims(data.claims())
+                .issuer(jwtProperties.getIssuer())
+                .issuedAt(now)
+                .expiration(expiry)
+                .signWith(secretKey)
                 .compact();
 
-
         logger.debug("Token generated successfully with expiration at {}", expiry);
-
         return token;
     }
 
@@ -61,13 +57,11 @@ public class JwtServiceImpl implements JwtService {
     public Claims validateToken(String token) throws JwtValidationException {
         logger.debug("Validating JWT token");
         try {
-            Claims claims = Jwts.parserBuilder()
-                    .setSigningKey(secretKey)
+            return Jwts.parser()
+                    .verifyWith(secretKey)
                     .build()
-                    .parseClaimsJws(token)
-                    .getBody();
-            logger.info("JWT token successfully validated for subject: {}", claims.getSubject());
-            return claims;
+                    .parseSignedClaims(token)
+                    .getPayload(); // payload() replaces getBody()
 
         } catch (JwtException ex) {
             logger.warn("Token validation failed: {}", ex.getMessage());
@@ -107,19 +101,18 @@ public class JwtServiceImpl implements JwtService {
     public String generateVerificationToken(JwtTokenData data) {
         logger.info("Generating verification token for subject: {}", data.subject());
         Date now = new Date();
-        Date expiry = new Date(now.getTime() + Duration.ofDays(28).toMillis()); // 4 weeks
+        Date expiry = new Date(now.getTime() + Duration.ofDays(28).toMillis());
 
         String token = Jwts.builder()
-                .setSubject(data.subject())
-                .addClaims(data.claims())
-                .setIssuer(jwtProperties.getIssuer())
-                .setIssuedAt(now)
-                .setExpiration(expiry)
-                .signWith(secretKey, SignatureAlgorithm.HS256)
+                .subject(data.subject())
+                .claims(data.claims())
+                .issuer(jwtProperties.getIssuer())
+                .issuedAt(now)
+                .expiration(expiry)
+                .signWith(secretKey)
                 .compact();
 
         logger.debug("Verification token generated successfully with 4-week expiration at {}", expiry);
         return token;
     }
-
 }

--- a/user-service/Dockerfile
+++ b/user-service/Dockerfile
@@ -1,16 +1,10 @@
-# Step 1: Build Stage
-FROM maven:3.9-eclipse-temurin-17 AS build
-WORKDIR /app
-COPY pom.xml .
-RUN mvn dependency:go-offline
-COPY src ./src
-RUN mvn clean package -DskipTests
-
-# Step 2: Runtime Stage
 FROM eclipse-temurin:17-jre
 WORKDIR /app
 RUN addgroup --system appgroup && adduser --system appuser --ingroup appgroup
-COPY --from=build /app/target/*.jar app.jar
+
+# Just grab the jar we compiled on your host machine in Step 1
+COPY target/*.jar app.jar
+
 RUN chown appuser:appgroup app.jar
 USER appuser
 EXPOSE 8081

--- a/user-service/pom.xml
+++ b/user-service/pom.xml
@@ -1,44 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.4.5</version>
-		<relativePath/> <!-- lookup parent from repository -->
-	</parent>
+		<version>4.0.7</version> <relativePath/> </parent>
 	<groupId>com.miniedu</groupId>
 	<artifactId>user-service</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
 	<name>user-service</name>
 	<description>User Microservice for MiniEdu</description>
 	<url/>
-	<licenses>
-		<license/>
-	</licenses>
-	<developers>
-		<developer/>
-	</developers>
-	<scm>
-		<connection/>
-		<developerConnection/>
-		<tag/>
-		<url/>
-	</scm>
+
 	<properties>
 		<java.version>17</java.version>
-		<spring-cloud.version>2024.0.1</spring-cloud.version>
+		<spring-cloud.version>2025.1.0</spring-cloud.version>
 	</properties>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
 		</dependency>
-<!--		<dependency>-->
-<!--			<groupId>org.springframework.boot</groupId>-->
-<!--			<artifactId>spring-boot-starter-security</artifactId>-->
-<!--		</dependency>-->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-validation</artifactId>
@@ -91,14 +75,21 @@
 		</dependency>
 
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
+
+		<dependency>
 			<groupId>io.github.danikofficial</groupId>
 			<artifactId>security-lib</artifactId>
-			<version>1.0.0</version>
+			<version>1.1.0</version>
 		</dependency>
+
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
 		</dependency>
+
 		<dependency>
 			<groupId>io.github.danikofficial</groupId>
 			<artifactId>miniedu-model</artifactId>
@@ -150,5 +141,4 @@
 			</plugin>
 		</plugins>
 	</build>
-
 </project>

--- a/user-service/src/main/java/com/miniedu/userservice/kafka/config/KafkaConfiguration.java
+++ b/user-service/src/main/java/com/miniedu/userservice/kafka/config/KafkaConfiguration.java
@@ -1,15 +1,12 @@
 package com.miniedu.userservice.kafka.config;
 
-import com.miniedu.model.kafka.events.EmailEvent;
-import org.apache.kafka.clients.producer.ProducerConfig;
-import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.NewTopic;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.kafka.core.DefaultKafkaProducerFactory;
-import org.springframework.kafka.core.KafkaTemplate;
-import org.springframework.kafka.core.ProducerFactory;
-import org.springframework.kafka.support.serializer.JsonSerializer;
+import org.springframework.kafka.config.TopicBuilder;
+import org.springframework.kafka.core.KafkaAdmin;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -20,18 +17,21 @@ public class KafkaConfiguration {
     @Value("${spring.kafka.bootstrap-servers}")
     private String bootstrapServers;
 
+    @Value("${kafka.topics.emailEvents}")
+    private String emailEventsTopic;
+
     @Bean
-    public ProducerFactory<String, EmailEvent> producerFactory() {
-        Map<String, Object> configProps = new HashMap<>();
-        configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
-        configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
-        configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
-        configProps.put(JsonSerializer.ADD_TYPE_INFO_HEADERS, true);
-        return new DefaultKafkaProducerFactory<>(configProps);
+    public KafkaAdmin kafkaAdmin() {
+        Map<String, Object> configs = new HashMap<>();
+        configs.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        return new KafkaAdmin(configs);
     }
 
     @Bean
-    public KafkaTemplate<String, EmailEvent> kafkaTemplate(ProducerFactory<String, EmailEvent> producerFactory) {
-        return new KafkaTemplate<>(producerFactory);
+    public NewTopic userEmailTopic() {
+        return TopicBuilder.name(emailEventsTopic)
+                .partitions(1)
+                .replicas(1)
+                .build();
     }
 }

--- a/user-service/src/main/resources/application.yml
+++ b/user-service/src/main/resources/application.yml
@@ -4,6 +4,13 @@ spring:
   config:
     import: "configserver:${CONFIG_SERVER_URL:http://localhost:8888}"
     name: user-service
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS}
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+      properties:
+        spring.json.add.type.headers: true
 
 server:
   port: 8081


### PR DESCRIPTION
- Fixed topic name mismatch: KafkaConfiguration now reads topic name from ${kafka.topics.emailEvents} instead of hardcoded string, aligning producer and consumer on the same topic
- Removed manual ProducerFactory and KafkaTemplate beans — Spring Boot autoconfigures from application.yml properties (Spring Kafka 4.x)
- Moved serializer/deserializer config to application.yml for both user-service and email-service
- Added NewTopic and KafkaAdmin beans to guarantee topic exists at user-service startup, not on first message send
- Added actuator dependency to user-service for healthcheck support
- Added user-service healthcheck and email-service depends_on condition to enforce startup order and eliminate consumer race condition
- Cleaned up Dockerfiles and pom.xml dependencies across services